### PR TITLE
DP-9 Timestamp Not Visible on LoL Command

### DIFF
--- a/commands/apex.py
+++ b/commands/apex.py
@@ -118,7 +118,7 @@ async def Apex(interaction: discord.Interaction, platform: Literal['Xbox', 'Play
             # Add the dynamic fields to the embed
             embed.add_field(name=f"{activeLegendName} - Currently Selected", value='\n'.join(embed_fields), inline=False)
 
-            embed.timestamp = datetime.datetime.utcnow()
+            embed.timestamp = datetime.datetime.now(datetime.UTC)
             embed.set_footer(text="Built By Goldiez ❤️")
             await interaction.response.send_message(embed=embed)
 

--- a/commands/fortnite.py
+++ b/commands/fortnite.py
@@ -44,7 +44,7 @@ async def fortnite(interaction: discord.Interaction, *, name: str):
 
         # Similar fields can be added for Solo, Duo, Trio, Squad, LTMs, Input Methods, etc.
 
-        embed.timestamp = datetime.datetime.utcnow()
+        embed.timestamp = datetime.datetime.now(datetime.UTC)
         embed.set_footer(text="Built By Goldiez ❤️")
         await interaction.response.send_message(embed=embed)
 

--- a/commands/help.py
+++ b/commands/help.py
@@ -11,7 +11,7 @@ async def help(interaction: discord.Interaction):
     embed.add_field(name="TFT Player Stats", value="`/tft <Summoner#0001>`")
     embed.add_field(name="Fortnite Player Stats", value="`/fortnite <name>`")
     embed.add_field(name="Horoscope", value="`/horoscope <sign>`")
-    embed.timestamp = datetime.datetime.utcnow()
+    embed.timestamp = datetime.datetime.now(datetime.UTC)
     embed.set_footer(text="Built By Goldiez ❤️")
     await interaction.response.send_message(embed=embed)
 

--- a/commands/horoscope.py
+++ b/commands/horoscope.py
@@ -45,7 +45,7 @@ async def horoscope(interaction: discord.Interaction, sign: SignLiteral):
 
         embed = discord.Embed(title=f"Horoscope for {signs[given_sign]['display']}", color=0xdd4f7a)
         embed.add_field(name="Today's Horoscope", value=horoscope_text, inline=False)
-        embed.timestamp = datetime.datetime.utcnow()
+        embed.timestamp = datetime.datetime.now(datetime.UTC)
         embed.set_footer(text="Built By Goldiez ❤️")
         await interaction.response.send_message(embed=embed)
 

--- a/commands/league.py
+++ b/commands/league.py
@@ -78,8 +78,8 @@ async def league(interaction: discord.Interaction, riotid: str):
 
         league_info = f"{tier} {rank} {lp} LP\nWins: {wins}\nLosses: {losses}\nWinrate: {winrate}%"
         embed.add_field(name=user_friendly_queue_type, value=league_info, inline=True)
-
-    embed.set_footer(text="Built By Goldiez ❤️")
+        embed.timestamp = datetime.datetime.now(datetime.UTC)
+        embed.set_footer(text="Built By Goldiez ❤️")
 
     await interaction.followup.send(embed=embed)
 

--- a/commands/tft.py
+++ b/commands/tft.py
@@ -72,8 +72,8 @@ async def tft(interaction: discord.Interaction, riotid: str):
 
         league_info = f"{tier} {rank} {lp} LP\nWins: {wins}\nLosses: {losses}\nWinrate: {winrate}%"
         embed.add_field(name=user_friendly_queue_type, value=league_info, inline=True)
-
-    embed.set_footer(text="Built By Goldiez ❤️")
+        embed.timestamp = datetime.datetime.now(datetime.UTC)
+        embed.set_footer(text="Built By Goldiez ❤️")
 
     await interaction.followup.send(embed=embed)
 


### PR DESCRIPTION
Fixed timestamp bug on LoL command and updated all timestamps as old one is now deprecated.