### PR TITLE
[OPS-18] feat(Pet Battles): Add killstreak and loss streak tracking to pet battles

### DIFF
--- a/commands/show_update.py
+++ b/commands/show_update.py
@@ -3,13 +3,7 @@ import discord
 # Easily editable text for the latest updates
 LATEST_UPDATES = """
 - **Version 1.2.3**:
-  Introducing Pet Battles!
-
-  Now you can create your own server pet, battle other pets in the server, level up and compete in the leaderboards for the top spot!
-
-  Get started with /help to see all the commands including all related to Pet Battles!
-
-  If you require support, please contact via https://astrostats.vercel.app/
+  Killstreaks and Loss streaks have been added into your pet stats! 
 """
 
 async def show_update(interaction: discord.Interaction):


### PR DESCRIPTION


- Implemented tracking of killstreaks and loss streaks for pets during battles.
- Updated the `pet_stats` command to display either the killstreak or loss streak in the footer, depending on which one is active.
- Ensured backward compatibility by initializing killstreak and loss streak fields for existing pets during their next battle or stats view.
- Refactored battle logic to update killstreaks and loss streaks based on the outcome of each battle.