### PR TITLE
fix(league): Added missing value param to embed.add_field().

### DIFF
--- a/commands/league.py
+++ b/commands/league.py
@@ -137,9 +137,6 @@ async def add_live_game_data_to_embed(embed: discord.Embed, live_game_data: dict
             else:
                 red_team.append(player_data)
     
-        # Add a divider field for Live Game Info
-        embed.add_field(name="\u200b", value="**Currently In Game**", inline=False)
-    
         # Display the game mode (or queue configuration)
         queue_config_id = live_game_data.get("gameQueueConfigId")
         if queue_config_id:
@@ -156,7 +153,7 @@ async def add_live_game_data_to_embed(embed: discord.Embed, live_game_data: dict
             }.get(queue_config_id, f"Queue ID {queue_config_id}")
         else:
             game_mode_name = live_game_data.get("gameMode", "Unknown")
-        embed.add_field(name=f"Game Mode: {game_mode_name}", inline=False)
+        embed.add_field(name="\u200b", value=f"**Currently In Game - {game_mode_name}**", inline=False)
     
         blue_team_champions = '\n'.join([
             f"{await get_emoji_for_champion(p['champion_name'])} {p['champion_name']}" for p in blue_team


### PR DESCRIPTION
Error was sitting at this line: `embed.add_field(name=f"Game Mode: {game_mode_name}", inline=False)`
The fix should was changing it to `embed.add_field(name="\u200b", value=f"**Currently In Game - {game_mode_name}**", inline=False)`

Tested and now working

![LEAGUE_COMMAND_FIX](https://github.com/user-attachments/assets/41bd9fb6-e440-45d3-b625-15c6567050c8)


