### PR TITLE
fix(league): Ensure league data is a list and handle tier capitalisation

### DIFF
--- a/commands/league.py
+++ b/commands/league.py
@@ -217,15 +217,19 @@ async def get_player_rank(session: aiohttp.ClientSession, puuid: str, region: st
         summoner_data = await fetch_summoner_data(session, puuid, region, headers)
         if not summoner_data:
             return "Unranked"
-    
+
         summoner_id = summoner_data.get('id')
         league_data = await fetch_league_data(session, summoner_id, region, headers)
-        if not league_data:
+        if not isinstance(league_data, list):
             return "Unranked"
-    
+
         for entry in league_data:
-            if entry['queueType'] == 'RANKED_SOLO_5x5':
-                tier = entry.get('tier', 'Unranked').capitalize()
+            if isinstance(entry, dict) and entry.get('queueType') == 'RANKED_SOLO_5x5':
+                tier = entry.get('tier') or "Unranked"
+                if isinstance(tier, str):
+                    tier = tier.capitalize()
+                else:
+                    tier = "Unranked"
                 rank = entry.get('rank', '').upper()
                 lp = entry.get('leaguePoints', 0)
                 return f"{tier} {rank} {lp} LP"


### PR DESCRIPTION
This pull request includes a change to the `get_player_rank` function in the `commands/league.py` file to improve its robustness and error handling. The most important changes include adding type checks and refining the logic for determining the player's rank.

Improvements to error handling and robustness:

* [`commands/league.py`](diffhunk://#diff-c5e117ffcfbf0ae6d342b5464126107ef715815886533d9e7107a3867d2a9d0cL223-R232): Modified the `get_player_rank` function to check if `league_data` is a list and to ensure entries in the list are dictionaries before processing. This prevents potential runtime errors when the data structure is not as expected.
* [`commands/league.py`](diffhunk://#diff-c5e117ffcfbf0ae6d342b5464126107ef715815886533d9e7107a3867d2a9d0cL223-R232): Enhanced the logic for determining the player's rank by adding type checks for the `tier` value and ensuring it is capitalized only if it is a string. This ensures the rank information is formatted correctly.