### PR TITLE
OPS-3 fix(league): Ranked Flex now shows by default.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -153,7 +153,7 @@ async def setup_commands():
     await squib_game_commands.setup(client)
 
 
-@tasks.loop(minutes=60)
+@tasks.loop(minutes=20)
 async def poll_jira():
     global processed_issues
     auth = aiohttp.BasicAuth(JIRA_EMAIL, JIRA_API_TOKEN)


### PR DESCRIPTION
This pull request includes several changes to the `bot.py` and `commands/league.py` files to improve the bot's functionality and user experience. The most important changes include adjusting the polling interval for Jira tasks, improving the readability of the `add_live_game_data_to_embed` function, and ensuring that ranked information is always displayed in a consistent format.

Changes to `bot.py`:

* Adjusted the polling interval for Jira tasks from 60 minutes to 20 minutes to ensure more frequent updates.

Changes to `commands/league.py`:

* Improved the readability of the `add_live_game_data_to_embed` function by splitting a long line into multiple lines.
* Added default values for ranked queues to ensure that "Ranked Solo/Duo" and "Ranked Flex 5v5" are always displayed, even if the user is unranked.
* Modified the `profile` function to always add fields for "Ranked Solo/Duo" and "Ranked Flex 5v5" in the embed, ensuring consistent display of ranked information.