### PR TITLE
AB-3 fix(jira): Remove configuration for Diverse Diaries project

### DIFF
--- a/utils/jira_poll.py
+++ b/utils/jira_poll.py
@@ -28,16 +28,6 @@ JIRA_PROJECTS = {
         "thumbnail": "https://astrostats.vercel.app/images/astrostats.png",
         "attachment_file": None,
     },
-    "Diverse Diaries": {
-        "base_url": os.getenv("JIRA_BASE_URL"),
-        "email": os.getenv("JIRA_EMAIL"),
-        "token": os.getenv("JIRA_API_TOKEN"),
-        "jql": 'project = "Diverse Diaries" AND type = Bug',
-        "fields": "key,summary,description,issuetype,attachment,status,priority,components,reporter,project",
-        # Diverse Diaries uses the same image as AstroStats.
-        "thumbnail": "https://astrostats.vercel.app/images/astrostats.png",
-        "attachment_file": None,
-    },
 }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `utils/jira_poll.py` file. The change removes the configuration for the "Diverse Diaries" project, which includes the base URL, email, token, JQL query, and other related fields.

* [`utils/jira_poll.py`](diffhunk://#diff-db26d3061e6310e4e67b9788004af2cffe2f06859b930ef30e9e2330f7fa91baL31-L40): Removed the configuration for the "Diverse Diaries" project, including base URL, email, token, JQL query, and other related fields.