### PR TITLE
AB-5 fix: Add mapping for Master Yi in champion name normalisation

### DIFF
--- a/commands/league.py
+++ b/commands/league.py
@@ -48,6 +48,7 @@ SPECIAL_EMOJI_NAMES = {
     "Kai'Sa": "KaiSa",
     "Vel'Koz": "Velkoz",
     "Kha'Zix": "Khazix",
+    "Master Yi": "MasterYi",
 }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `commands/league.py` file. The change adds an entry to the dictionary to map the name "Master Yi" to "MasterYi".

* [`commands/league.py`](diffhunk://#diff-c5e117ffcfbf0ae6d342b5464126107ef715815886533d9e7107a3867d2a9d0cR51): Added a mapping for "Master Yi" to "MasterYi".