### PR TITLE
fix(jira): Remove attachment file reference for Diverse Diaries

### DIFF
--- a/utils/jira_poll.py
+++ b/utils/jira_poll.py
@@ -35,7 +35,7 @@ JIRA_PROJECTS = {
         "jql": 'project = "Diverse Diaries" AND type = Bug',
         "fields": "key,summary,description,issuetype,attachment,status,priority,components,reporter,project",
         "thumbnail": "attachment://diversediaries.png",
-        "attachment_file": "images/diversediaries.png",
+        "attachment_file": None,
     },
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `utils/jira_poll.py` file. The change sets the `attachment_file` field to `None` instead of specifying an image file.

* [`utils/jira_poll.py`](diffhunk://#diff-db26d3061e6310e4e67b9788004af2cffe2f06859b930ef30e9e2330f7fa91baL38-R38): Changed the `attachment_file` field to `None` for the "Diverse Diaries" project.