### PR TITLE
feat(apex): Add ResourceNotFoundError handling for player stats

### DIFF
--- a/cogs/games/apex.py
+++ b/cogs/games/apex.py
@@ -8,7 +8,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from config.constants import APEX_PLATFORM_MAPPING
-from core.errors import send_error_embed
+from core.errors import send_error_embed, ResourceNotFoundError
 from services.api.apex import fetch_apex_stats, format_stat_value
 from core.utils import get_conditional_embed
 
@@ -39,6 +39,15 @@ class ApexCog(commands.Cog):
 
             try:
                 data = await asyncio.to_thread(fetch_apex_stats, platform, name)
+            except ResourceNotFoundError as e:
+                logger.warning(f"Resource Not Found: {e}", exc_info=True)
+                await send_error_embed(
+                    interaction,
+                    "Account Not Found",
+                    f"No stats found for the username: **{name}** on **{platform}**. "
+                    "Please ensure the username and platform are correct and the profile exists on [Apex Tracker](https://apex.tracker.gg)."
+                )
+                return
             except Exception as e:
                 logger.error(f"API Error: {e}", exc_info=True)
                 await send_error_embed(


### PR DESCRIPTION
This pull request introduces an enhancement to the error handling in the Apex stats command by adding a specific exception for cases where a resource is not found. The changes improve the user experience by providing a clearer and more actionable error message when a username or platform is invalid or not found.

### Enhancements to error handling:

* [`cogs/games/apex.py`](diffhunk://#diff-50f012d61b18fbfd824f9ce225591dbc1f48d0d8a58d8bf4faf8ea9aa653aff2L11-R11): Imported the `ResourceNotFoundError` exception from `core.errors` to handle cases where Apex stats cannot be found.
* [`cogs/games/apex.py`](diffhunk://#diff-50f012d61b18fbfd824f9ce225591dbc1f48d0d8a58d8bf4faf8ea9aa653aff2R42-R50): Updated the `apex` command to catch `ResourceNotFoundError`, log a warning, and send a user-friendly error embed indicating that the account was not found. The error message includes guidance to check the username and platform on Apex Tracker.