### PR TITLE
refactor(league): Replace summoner_name with riotId for player identity

### DIFF
--- a/cogs/games/league.py
+++ b/cogs/games/league.py
@@ -388,7 +388,7 @@ class LeagueCog(commands.GroupCog, group_name="league"):
                 for i in range(0, len(arena_players), 2):
                     team = arena_players[i:i + 2]
                     team_details = "\n".join([
-                        f"{await self.get_emoji_for_champion(p['champion_name'])} {p['champion_name']} - {p['summoner_name']} ({p['rank']})"
+                        f"{await self.get_emoji_for_champion(p['champion_name'])} {p['champion_name']} - {p['riotId']} ({p['rank']})"
                         for p in team
                     ])
                     embed.add_field(name=f"Team {i // 2 + 1}", value=team_details, inline=True)
@@ -421,13 +421,13 @@ class LeagueCog(commands.GroupCog, group_name="league"):
                 blue_team_champions = '\n'.join([
                     f"{await self.get_emoji_for_champion(p['champion_name'])} {p['champion_name']}" for p in blue_team
                 ]) or "No data"
-                blue_team_names = '\n'.join([p['summoner_name'] for p in blue_team]) or "No data"
+                blue_team_names = '\n'.join([p['riotId'] for p in blue_team]) or "No data"
                 blue_team_ranks = '\n'.join([p['rank'] for p in blue_team]) or "No data"
 
                 red_team_champions = '\n'.join([
                     f"{await self.get_emoji_for_champion(p['champion_name'])} {p['champion_name']}" for p in red_team
                 ]) or "No data"
-                red_team_names = '\n'.join([p['summoner_name'] for p in red_team]) or "No data"
+                red_team_names = '\n'.join([p['riotId'] for p in red_team]) or "No data"
                 red_team_ranks = '\n'.join([p['rank'] for p in red_team]) or "No data"
 
                 embed.add_field(name="Blue Team", value=blue_team_champions, inline=True)
@@ -464,18 +464,19 @@ class LeagueCog(commands.GroupCog, group_name="league"):
             if account_data:
                 game_name = account_data.get('gameName', 'Unknown')
                 tag_line = account_data.get('tagLine', '')
-                summoner_name = f"{game_name}#{tag_line}" if tag_line else game_name
+                riotId = f"{game_name}#{tag_line}" if tag_line else game_name
             else:
-                summoner_name = player.get('summonerName', 'Unknown')
+                # Try riotId first, then summonerName, finally default to 'Unknown'
+                riotId = player.get('riotId') or player.get('summonerName', 'Unknown')
 
             rank = await self.get_player_rank(session, summoner_id, region, headers)
             champion_id = player['championId']
             champion_name = await self.fetch_champion_name(session, champion_id)
 
-            return {'summoner_name': summoner_name, 'champion_name': champion_name, 'rank': rank}, team_id
+            return {'riotId': riotId, 'champion_name': champion_name, 'rank': rank}, team_id
         except Exception as e:
             logger.error(f"Error fetching participant data: {e}")
-            return {'summoner_name': 'Unknown', 'champion_name': 'Unknown', 'rank': 'Unranked'}, player.get('teamId', 0)
+            return {'riotId': 'Unknown', 'champion_name': 'Unknown', 'rank': 'Unranked'}, player.get('teamId', 0)
 
     async def get_player_rank(self, session: aiohttp.ClientSession, summoner_id: str, region: str,
                               headers: dict) -> str:


### PR DESCRIPTION
This pull request updates the `cogs/games/league.py` file to replace the usage of `summoner_name` with `riotId` for better consistency and clarity in identifying players. The changes affect multiple methods where player data is processed and displayed.

### Transition from `summoner_name` to `riotId`:

* **Display updates in `add_live_game_data_to_embed`:**
  - Replaced `summoner_name` with `riotId` when displaying team details in the embed fields. This ensures that the Riot ID is consistently shown for players in both team compositions and names. [[1]](diffhunk://#diff-be9c17129a1b02a994c2b78fee8eb44e0f603f84595f629dce2a51911da84c56L391-R391) [[2]](diffhunk://#diff-be9c17129a1b02a994c2b78fee8eb44e0f603f84595f629dce2a51911da84c56L424-R430)

* **Data fetching logic in `fetch_participant_data`:**
  - Updated the logic to prioritize `riotId` over `summoner_name` when constructing player identifiers. The fallback order is now `riotId -> summoner_name -> 'Unknown'`.
  - Adjusted the returned data structure to replace `summoner_name` with `riotId`, ensuring uniformity in the data being passed to other parts of the application.