### PR TITLE
feat(images): Add astrostats image path and update embed footers across multiple cogs

### DIFF
--- a/cogs/games/apex.py
+++ b/cogs/games/apex.py
@@ -1,6 +1,7 @@
 ﻿import datetime
 import logging
 import asyncio
+import os
 from typing import Literal, Dict
 
 import discord
@@ -18,6 +19,9 @@ logger = logging.getLogger(__name__)
 class ApexCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        # Get the absolute path to the images
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     @app_commands.command(name="apex", description="Check your Apex Legends Player Stats")
     async def apex(
@@ -92,7 +96,10 @@ class ApexCog(commands.Cog):
             if conditional_embed:
                 embeds.append(conditional_embed)
 
-            await interaction.followup.send(embeds=embeds)
+            await interaction.followup.send(
+                embeds=embeds, 
+                files=[discord.File(self.astrostats_img, "astrostats.png")]
+            )
 
         except ValueError as e:
             logger.error(f"Validation Error: {e}", exc_info=True)
@@ -156,7 +163,7 @@ class ApexCog(commands.Cog):
             value="[If you enjoy using this bot, consider supporting us!](https://buymeacoffee.com/danblock97)",
             inline=False
         )
-        embed.set_footer(text="Built By Goldiez ❤️ Support: https://astrostats.vercel.app")
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
         return embed
 
     def format_lifetime_stats(self, lifetime: Dict) -> str:

--- a/cogs/games/fortnite.py
+++ b/cogs/games/fortnite.py
@@ -1,6 +1,7 @@
 ﻿import datetime
 import logging
 import urllib.parse
+import os
 from typing import Literal, Optional, Dict
 
 import discord
@@ -19,6 +20,9 @@ logger = logging.getLogger(__name__)
 class FortniteCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        # Get the absolute path to the images
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     async def fetch_fortnite_stats(self, name: str, time_window: str) -> Optional[Dict]:
         if not FORTNITE_API_KEY:
@@ -108,7 +112,10 @@ class FortniteCog(commands.Cog):
             if conditional_embed:
                 embeds.append(conditional_embed)
 
-            await interaction.followup.send(embeds=embeds)
+            await interaction.followup.send(
+                embeds=embeds,
+                files=[discord.File(self.astrostats_img, "astrostats.png")]
+            )
 
         except ValueError as e:
             logger.error(f"Validation Error: {e}", exc_info=True)
@@ -185,7 +192,7 @@ class FortniteCog(commands.Cog):
             value="[If you enjoy using this bot, consider supporting us!](https://buymeacoffee.com/danblock97)"
         )
         embed.timestamp = datetime.datetime.now(datetime.timezone.utc)
-        embed.set_footer(text="Built By Goldiez ❤️ Support: https://astrostats.vercel.app")
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
         return embed
 
 

--- a/cogs/games/league.py
+++ b/cogs/games/league.py
@@ -31,6 +31,8 @@ class LeagueCog(commands.GroupCog, group_name="league"):
         self.bot = bot
         self.emojis = {}  # Local emoji cache for the cog
         self.bot.loop.create_task(self.initialize_emojis())
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     async def initialize_emojis(self):
         """Initialize emoji data when the cog is loaded."""
@@ -167,7 +169,7 @@ class LeagueCog(commands.GroupCog, group_name="league"):
                     inline=False
                 )
                 embed.timestamp = datetime.datetime.now(datetime.timezone.utc)
-                embed.set_footer(text="Built By Goldiez ❤️ Visit clutchgg.lol for more!")
+                embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
 
                 conditional_embed = await get_conditional_embed(interaction, 'LEAGUE_EMBED', discord.Color.orange())
                 embeds = [embed]

--- a/cogs/games/tft.py
+++ b/cogs/games/tft.py
@@ -1,4 +1,5 @@
-﻿import datetime
+﻿import os
+import datetime
 import logging
 from typing import Literal, Optional
 
@@ -18,6 +19,8 @@ logger = logging.getLogger(__name__)
 class TFTCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     @app_commands.command(name="tft", description="Check your TFT Player Stats!")
     async def tft(self, interaction: discord.Interaction, region: Literal[
@@ -137,7 +140,7 @@ class TFTCog(commands.Cog):
                 )
             )
             embed.timestamp = datetime.datetime.now(datetime.timezone.utc)
-            embed.set_footer(text="Built By Goldiez ❤️ Support: https://astrostats.vercel.app")
+            embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
 
             # Add Conditional Embed
             conditional_embed = await get_conditional_embed(

--- a/cogs/general/help.py
+++ b/cogs/general/help.py
@@ -1,5 +1,4 @@
-﻿import datetime
-
+﻿import os
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -11,6 +10,8 @@ from ui.embeds import create_base_embed # Import create_base_embed
 class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     def build_help_embed(self) -> discord.Embed:
         guild_count = len(self.bot.guilds)
@@ -61,6 +62,7 @@ class HelpCog(commands.Cog):
             value="[If you enjoy using this bot, consider supporting us!](https://buymeacoffee.com/danblock97)",
             inline=False
         )
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
         return embed
 
     @app_commands.command(name="help", description="Lists all available commands")

--- a/cogs/general/horoscope.py
+++ b/cogs/general/horoscope.py
@@ -1,7 +1,7 @@
 ﻿import datetime
 import logging
-from typing import Literal, Optional
-
+from typing import Optional
+import os
 import aiohttp
 import discord
 from discord import app_commands
@@ -31,6 +31,8 @@ SIGNS = {
 class HoroscopeCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     async def fetch_horoscope_text(self, sign: str) -> Optional[str]:
         url = (
@@ -129,7 +131,7 @@ class HoroscopeCog(commands.Cog):
             inline=False
         )
         embed.timestamp = datetime.datetime.now(datetime.timezone.utc)
-        embed.set_footer(text="Built By Goldiez ❤️ Support: https://astrostats.vercel.app")
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
         return embed
 
     @app_commands.command(name="horoscope", description="Check your Daily Horoscope")

--- a/cogs/general/review.py
+++ b/cogs/general/review.py
@@ -1,12 +1,14 @@
 ﻿import discord
 from discord import app_commands
 from discord.ext import commands
-
+import os
 from core.utils import get_conditional_embed
 
 class ReviewCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     @app_commands.command(name="review", description="Leave a review on Top.gg")
     async def review(self, interaction: discord.Interaction):
@@ -33,6 +35,7 @@ class ReviewCog(commands.Cog):
                 "(https://buymeacoffee.com/danblock97)"
             )
         )
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
 
         # Fetch Conditional Embed
         conditional_embed = await get_conditional_embed(

--- a/cogs/general/show_update.py
+++ b/cogs/general/show_update.py
@@ -1,7 +1,7 @@
 ﻿import discord
 from discord import app_commands
 from discord.ext import commands
-
+import os
 from config.constants import LATEST_UPDATES
 from core.utils import get_conditional_embed
 from ui.embeds import create_base_embed
@@ -9,6 +9,8 @@ from ui.embeds import create_base_embed
 class ShowUpdateCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     @app_commands.command(name="show_update", description="Show the latest update to AstroStats")
     async def show_update(self, interaction: discord.Interaction):
@@ -25,6 +27,8 @@ class ShowUpdateCog(commands.Cog):
                 "(https://buymeacoffee.com/danblock97)"
             )
         )
+
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
 
         # Fetch Conditional Embed
         conditional_embed = await get_conditional_embed(

--- a/cogs/general/support.py
+++ b/cogs/general/support.py
@@ -1,7 +1,7 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
-
+import os
 from core.utils import get_conditional_embed
 from ui.embeds import create_base_embed # Import create_base_embed
 
@@ -9,6 +9,8 @@ from ui.embeds import create_base_embed # Import create_base_embed
 class SupportCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.base_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.astrostats_img = os.path.join(self.base_path, 'images', 'astrostats.png')
 
     @app_commands.command(name="feedback", description="Submit feedback or feature requests for AstroStats")
     async def feedback_command(self, interaction: discord.Interaction):
@@ -24,6 +26,8 @@ class SupportCog(commands.Cog):
             ),
             color=discord.Color.blue()
         )
+
+        embed.set_footer(text="AstroStats | astrostats.vercel.app", icon_url="attachment://astrostats.png")
         conditional_embed = await get_conditional_embed(
             interaction, 'FEEDBACK_EMBED', discord.Color.orange()
         )


### PR DESCRIPTION
This pull request introduces consistent enhancements across multiple bot commands by adding an image footer to embeds and ensuring a reusable image path is defined for each cog. These changes improve the visual branding of the bot and simplify image management.

### Embed Enhancements
* Updated the footer text in embeds to "AstroStats | astrostats.vercel.app" and included an image icon (`astrostats.png`) as an attachment across all applicable commands. [[1]](diffhunk://#diff-50f012d61b18fbfd824f9ce225591dbc1f48d0d8a58d8bf4faf8ea9aa653aff2L159-R166) [[2]](diffhunk://#diff-ac6884431c8d8e17dc3ff28e27025c588dbef9319d3efde2bb29606535ebedabL188-R195) [[3]](diffhunk://#diff-be9c17129a1b02a994c2b78fee8eb44e0f603f84595f629dce2a51911da84c56L170-R172) [[4]](diffhunk://#diff-6f89a7c7cff802de154f881fc015271f1bf8ae3d5435ee55d708b75c3a397e31L140-R143) [[5]](diffhunk://#diff-d489b7e41be919bdfd2729d00502306061c0e907b48d2336f076a14357ea3a20R65) [[6]](diffhunk://#diff-d5868403bc55fd54e38da15d3d23e40308f10754572618c83af97fcb84469762L132-R134) [[7]](diffhunk://#diff-cf11057370aee0a69c8fb6b01c91b1d098cfe30147c01e15287040e8a0b5c93cR38) [[8]](diffhunk://#diff-7794ddb4bd947093edbdd70c95e4547064792d042e0a23b27f679501881e4ab9R31-R32) [[9]](diffhunk://#diff-1b9d7c1c9a543183182e4fcc84fa21c59a810d1ce1731fe11d3b8df2afa8aedeR29-R30)

### Image Path Management
* Introduced a `base_path` attribute in each cog to dynamically compute the absolute path to the `astrostats.png` image, ensuring consistent access to the image file. [[1]](diffhunk://#diff-50f012d61b18fbfd824f9ce225591dbc1f48d0d8a58d8bf4faf8ea9aa653aff2R22-R24) [[2]](diffhunk://#diff-ac6884431c8d8e17dc3ff28e27025c588dbef9319d3efde2bb29606535ebedabR23-R25) [[3]](diffhunk://#diff-be9c17129a1b02a994c2b78fee8eb44e0f603f84595f629dce2a51911da84c56R34-R35) [[4]](diffhunk://#diff-6f89a7c7cff802de154f881fc015271f1bf8ae3d5435ee55d708b75c3a397e31R22-R23) [[5]](diffhunk://#diff-d489b7e41be919bdfd2729d00502306061c0e907b48d2336f076a14357ea3a20R13-R14) [[6]](diffhunk://#diff-d5868403bc55fd54e38da15d3d23e40308f10754572618c83af97fcb84469762R34-R35) [[7]](diffhunk://#diff-cf11057370aee0a69c8fb6b01c91b1d098cfe30147c01e15287040e8a0b5c93cL4-R11) [[8]](diffhunk://#diff-7794ddb4bd947093edbdd70c95e4547064792d042e0a23b27f679501881e4ab9L4-R13) [[9]](diffhunk://#diff-1b9d7c1c9a543183182e4fcc84fa21c59a810d1ce1731fe11d3b8df2afa8aedeL4-R13)

### Command-Specific Updates
* Modified commands like `apex`, `fortnite`, `tft`, and others to send the `astrostats.png` image as a file attachment alongside embeds. [[1]](diffhunk://#diff-50f012d61b18fbfd824f9ce225591dbc1f48d0d8a58d8bf4faf8ea9aa653aff2L95-R102) [[2]](diffhunk://#diff-ac6884431c8d8e17dc3ff28e27025c588dbef9319d3efde2bb29606535ebedabL111-R118) [[3]](diffhunk://#diff-6f89a7c7cff802de154f881fc015271f1bf8ae3d5435ee55d708b75c3a397e31L140-R143)