### PR TITLE
fix(urls): Update profile URLs for League and TFT commands to point to the correct endpoints

### DIFF
--- a/cogs/games/league.py
+++ b/cogs/games/league.py
@@ -114,7 +114,7 @@ class LeagueCog(commands.GroupCog, group_name="league"):
                     "tagLine": tag_line,
                     "region": region
                 })
-                profile_url = f"https://www.clutchgg.lol/profile?{query_params}"
+                profile_url = f"https://www.clutchgg.lol/league/profile?{query_params}"
 
                 embed = discord.Embed(
                     title=f"{game_name}#{tag_line} - Level {summoner_data['summonerLevel']}",

--- a/cogs/games/tft.py
+++ b/cogs/games/tft.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 from typing import Literal, Optional
+from urllib.parse import urlencode
 
 import discord
 from discord import app_commands
@@ -95,9 +96,18 @@ class TFTCog(commands.Cog):
             )
             league_response = requests.get(league_url, headers=headers)
 
+            # Construct profile URL
+            query_params = urlencode({
+                "gameName": game_name,
+                "tagLine": tag_line,
+                "region": region
+            })
+            profile_url = f"https://www.clutchgg.lol/tft/profile?{query_params}"
+
             embed = discord.Embed(
                 title=f"{game_name}#{tag_line} - Level {summoner_data['summonerLevel']}",
-                color=0x1a78ae
+                color=0x1a78ae,
+                url=profile_url
             )
             embed.set_thumbnail(
                 url=(


### PR DESCRIPTION
This pull request updates the URL construction logic for profile links in the `league.py` and `tft.py` modules, ensuring consistency and adding functionality to embed URLs in Discord messages. Additionally, it introduces a new import to support URL encoding.

### Updates to profile URL construction:

* [`cogs/games/league.py`](diffhunk://#diff-be9c17129a1b02a994c2b78fee8eb44e0f603f84595f629dce2a51911da84c56L117-R117): Updated the `profile_url` to use the new endpoint `https://www.clutchgg.lol/league/profile` for League of Legends profiles.
* [`cogs/games/tft.py`](diffhunk://#diff-6f89a7c7cff802de154f881fc015271f1bf8ae3d5435ee55d708b75c3a397e31R99-R110): Added logic to construct a `profile_url` for Teamfight Tactics profiles using the `urlencode` function. The URL now points to `https://www.clutchgg.lol/tft/profile`.

### Code enhancements:

* [`cogs/games/tft.py`](diffhunk://#diff-6f89a7c7cff802de154f881fc015271f1bf8ae3d5435ee55d708b75c3a397e31R5): Added `urlencode` from `urllib.parse` to handle query parameter encoding for constructing URLs.