### PR TITLE
fix(support): Remove issue tracker links from feedback and bug reporting commands

### DIFF
--- a/cogs/general/support.py
+++ b/cogs/general/support.py
@@ -21,7 +21,6 @@ class SupportCog(commands.Cog):
                 "**1.** Visit the [AstroStats Website](https://astrostats.info)\n"
                 "**2.** Click on the 'Need Help' button\n"
                 "**3.** Fill out the form with your suggestion\n\n"
-                "Alternatively, check our issue tracker for tasks we are working on [Issue Tracker](https://solodev-initiatives.youtrack.cloud/agiles/183-3/current)\n\n"
                 "Your feedback helps make AstroStats better for everyone!"
             ),
             color=discord.Color.blue()
@@ -47,7 +46,6 @@ class SupportCog(commands.Cog):
                 "**1.** Visit the [AstroStats Website](https://astrostats.info)\n"
                 "**2.** Click on 'Need Help' button\n"
                 "**3.** Describe the issue in detail (including steps to reproduce)\n\n"
-                "Alternatively, check our issue tracker for tasks we are working on [Issue Tracker](https://solodev-initiatives.youtrack.cloud/agiles/183-3/current)\n\n"
                 "Your reports help us improve the bot's reliability!"
             ),
             color=discord.Color.red()


### PR DESCRIPTION
This pull request removes references to the external issue tracker from the `feedback_command` and `bug_command` methods in the `cogs/general/support.py` file. This simplifies the user instructions by focusing solely on the AstroStats website for feedback and bug reporting.

### Changes to user instructions:

* [`cogs/general/support.py`](diffhunk://#diff-1b9d7c1c9a543183182e4fcc84fa21c59a810d1ce1731fe11d3b8df2afa8aedeL24): Removed the alternative option to check the external issue tracker from the `feedback_command` method, leaving only the instructions to use the AstroStats website for feedback.
* [`cogs/general/support.py`](diffhunk://#diff-1b9d7c1c9a543183182e4fcc84fa21c59a810d1ce1731fe11d3b8df2afa8aedeL50): Removed the alternative option to check the external issue tracker from the `bug_command` method, focusing on reporting issues via the AstroStats website.